### PR TITLE
restructured `Directory.Build.props`

### DIFF
--- a/src/Akka.TestKit.MsTest.Tests/Akka.TestKit.MsTest.Tests.csproj
+++ b/src/Akka.TestKit.MsTest.Tests/Akka.TestKit.MsTest.Tests.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>$(TestFramework)</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -13,7 +12,10 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Update="FluentAssertions" Version="6.9.0" />
+    <PackageReference Include="FluentAssertions" Version="$(FluentAssertionsVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
+    <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestVersion)" />
+    <PackageReference Include="coverlet.collector" Version="3.2.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Akka.TestKit.MsTest/Akka.TestKit.MsTest.csproj
+++ b/src/Akka.TestKit.MsTest/Akka.TestKit.MsTest.csproj
@@ -1,12 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>$(LibraryFramework)</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Akka" Version="1.4.48" />
-    <PackageReference Include="Akka.TestKit" Version="1.4.48" />
+    <PackageReference Include="Akka.TestKit" Version="$(AkkaVersion)" />
+    <PackageReference Include="MSTest.TestFramework" Version="$(MSTestVersion)" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,12 +1,12 @@
 ﻿<Project>
 	<PropertyGroup>
-		<Copyright>Copyright © 2013-2022 Akka.NET Team</Copyright>
+		<Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
 		<Authors>Akka.NET Team</Authors>
 		<VersionPrefix>0.0.1</VersionPrefix>
 		<PackageReleaseNotes>- Fixed bugs</PackageReleaseNotes>
 		<PackageIcon>akkalogo.png</PackageIcon>
 		<PackageProjectUrl>
-			https://github.com/akkadotnet/Akka.TestKit.VsTest
+			https://github.com/akkadotnet/Akka.TestKit.MSTest
 		</PackageProjectUrl>
 		<License>
 			Apache License
@@ -220,11 +220,12 @@
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<IsPackable>false</IsPackable>
 	</PropertyGroup>
-	<ItemGroup>
-		<PackageReference Include="FluentAssertions" Version="6.9.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
-		<PackageReference Include="MSTest.TestAdapter" Version="3.0.2" />
-		<PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-		<PackageReference Include="coverlet.collector" Version="3.2.0" />
-	</ItemGroup>
+  	<PropertyGroup>
+	    <LibraryFramework>netstandard2.0</LibraryFramework>
+	    <TestFramework>net7.0</TestFramework>
+	    <MSTestVersion>3.0.2</MSTestVersion>
+	    <TestSdkVersion>17.4.1</TestSdkVersion>
+	    <AkkaVersion>1.4.48</AkkaVersion>
+	    <FluentAssertionsVersion>6.9.0</FluentAssertionsVersion>
+  	</PropertyGroup>
 </Project>


### PR DESCRIPTION
## Changes

need to avoid pulling in unnecessary dependencies into our distributable NuGet packages
