### PR TITLE
added v1.4.48 release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,2 +1,4 @@
-## [0.0.1] / 9 December 2022
-- Fixed bugs
+## [1.4.48] / 17 January 2023
+- Migrated from VSTest to MSTest
+- Upgraded to Akka.NET v1.4.48
+- Targeted `netstandard2.0`

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -2,8 +2,10 @@
 	<PropertyGroup>
 		<Copyright>Copyright © 2013-2023 Akka.NET Team</Copyright>
 		<Authors>Akka.NET Team</Authors>
-		<VersionPrefix>0.0.1</VersionPrefix>
-		<PackageReleaseNotes>- Fixed bugs</PackageReleaseNotes>
+		<VersionPrefix>1.4.48</VersionPrefix>
+		<PackageReleaseNotes>- Migrated from VSTest to MSTest
+- Upgraded to Akka.NET v1.4.48
+- Targeted `netstandard2.0`</PackageReleaseNotes>
 		<PackageIcon>akkalogo.png</PackageIcon>
 		<PackageProjectUrl>
 			https://github.com/akkadotnet/Akka.TestKit.MSTest


### PR DESCRIPTION
## [1.4.48] / 17 January 2023
- Migrated from VSTest to MSTest
- Upgraded to Akka.NET v1.4.48
- Targeted `netstandard2.0`