### PR TITLE
Bump AkkaVersion to 1.6.0

### DIFF
--- a/src/Akka.TestKit.MsTest.Tests/AssertionsTests.cs
+++ b/src/Akka.TestKit.MsTest.Tests/AssertionsTests.cs
@@ -4,6 +4,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 
+using Akka.Configuration;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Akka.TestKit.MsTest.Tests
@@ -20,17 +21,15 @@ namespace Akka.TestKit.MsTest.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(AssertFailedException))]
         public void Fail_should_throw()
         {
-            _assertions!.Fail();
+            Assert.ThrowsExactly<AssertFailedException>(() => _assertions!.Fail());
         }
 
         [TestMethod]
-        [ExpectedException(typeof(AssertFailedException))]
         public void AssertTrue_should_throw_on_false()
         {
-            _assertions!.AssertTrue(false);
+            Assert.ThrowsExactly<AssertFailedException>(() => _assertions!.AssertTrue(false));
         }
 
         [TestMethod]
@@ -40,10 +39,9 @@ namespace Akka.TestKit.MsTest.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(AssertFailedException))]
         public void AssertFalse_should_throw_on_true()
         {
-            _assertions!.AssertFalse(true);
+            Assert.ThrowsExactly<AssertFailedException>(() => _assertions!.AssertFalse(true));
         }
 
         [TestMethod]
@@ -54,10 +52,9 @@ namespace Akka.TestKit.MsTest.Tests
 
 
         [TestMethod]
-        [ExpectedException(typeof(AssertFailedException))]
         public void AssertEqual_should_throw_on_not_equal()
         {
-            _assertions!.AssertEqual(42, 4711);
+            Assert.ThrowsExactly<AssertFailedException>(() => _assertions!.AssertEqual(42, 4711));
         }
 
         [TestMethod]
@@ -68,18 +65,95 @@ namespace Akka.TestKit.MsTest.Tests
 
 
         [TestMethod]
-        [ExpectedException(typeof(AssertFailedException))]
         public void AssertEqualWithComparer_should_throw_on_not_equal()
         {
-            _assertions!.AssertEqual(42, 42,(x,y)=>false);
+            Assert.ThrowsExactly<AssertFailedException>(() => _assertions!.AssertEqual(42, 1142, Comparer));
         }
 
         [TestMethod]
         public void AssertEqualWithComparer_should_succeed_on_equal()
         {
-            _assertions!.AssertEqual(42, 4711,(x,y)=>true);
+            _assertions!.AssertEqual(42, 42, Comparer);
         }
 
+        private bool Comparer(int a, int b) => a == b;
+
+        [TestMethod]
+        [DynamicData(nameof(ExceptionData), DynamicDataSourceType.Method)]
+        public void Generic_AssertThrows_should_succeed_only_on_specific_exception(Exception exception)
+        {
+            if (exception is ConfigurationException ex)
+            {
+                // Should pass and return the same exception instance
+                var returned = _assertions!.AssertThrows<ConfigurationException>(ThisThrows);
+                Assert.AreEqual(ex, returned);
+            }
+            else
+            {
+                // Should fail the assertion since it's not the expected type
+                Assert.ThrowsExactly<AssertFailedException>(() =>
+                    _assertions!.AssertThrows<ConfigurationException>(ThisThrows));
+            }
+
+            void ThisThrows()
+            {
+                throw exception;
+            }
+        }
+
+        [TestMethod]
+        [DynamicData(nameof(ExceptionData), DynamicDataSourceType.Method)]
+        public async Task Generic_AssertThrows_should_succeed_only_on_specific_exception_async(Exception exception)
+        {
+            if (exception is ConfigurationException ex)
+            {
+                var returned = await _assertions!.AssertThrowsAsync<ConfigurationException>(ThisThrows);
+                Assert.AreEqual(ex, returned);
+            }
+            else
+            {
+                await Assert.ThrowsExactlyAsync<AssertFailedException>(async () =>
+                    await _assertions!.AssertThrowsAsync<ConfigurationException>(ThisThrows));
+            }
+
+            async Task ThisThrows()
+            {
+                await Task.Yield();
+                throw exception;
+            }
+        }
+
+        [TestMethod]
+        public void Generic_AssertThrows_should_fail_when_no_exception_was_thrown()
+        {
+            Assert.ThrowsExactly<AssertFailedException>(() =>
+                _assertions!.AssertThrows<ConfigurationException>(ThisDoesNotThrow));
+
+            void ThisDoesNotThrow()
+            {
+            }
+        }
+
+        [TestMethod]
+        public async Task Generic_AssertThrows_should_fail_when_no_exception_was_thrown_async()
+        {
+            await Assert.ThrowsExactlyAsync<AssertFailedException>(async () =>
+                await _assertions!.AssertThrowsAsync<ConfigurationException>(ThisDoesNotThrow));
+
+            async Task ThisDoesNotThrow()
+            {
+                await Task.Yield();
+            }
+        }
+
+        // Dynamic data source
+        public static IEnumerable<object[]> ExceptionData()
+        {
+            yield return [new Exception("Wheee")];
+            yield return [new ConfigurationException("Wheee")];
+            yield return [new TimeoutException("Wheee")];
+            yield return [new OperationCanceledException("Wheee")];
+        }
     }
 }
 

--- a/src/Akka.TestKit.MsTest/MsTestAssertions.cs
+++ b/src/Akka.TestKit.MsTest/MsTestAssertions.cs
@@ -5,6 +5,7 @@
 //-----------------------------------------------------------------------
 
 using System;
+using System.Threading.Tasks;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Akka.TestKit.MsTest
@@ -36,9 +37,29 @@ namespace Akka.TestKit.MsTest
         }
 
         public void AssertEqual<T>(T expected, T actual, Func<T, T, bool> comparer, string format = "", params object[] args)
-        {            
+        {
             if(!comparer(expected, actual))
                 throw new AssertFailedException(string.Format("Assert.AreEqual failed. Expected [{0}]. Actual [{1}]. {2}", FormatValue(expected), FormatValue(actual), string.Format(format,args)));
+        }
+
+        public Exception AssertThrows(Action action)
+        {
+            return Assert.Throws<Exception>(action);
+        }
+
+        public TException AssertThrows<TException>(Action action) where TException : Exception
+        {
+            return Assert.ThrowsExactly<TException>(action);
+        }
+
+        public Task<Exception> AssertThrowsAsync(Func<Task> action)
+        {
+            return Assert.ThrowsAsync<Exception>(action);
+        }
+
+        public Task<TException> AssertThrowsAsync<TException>(Func<Task> action) where TException : Exception
+        {
+            return Assert.ThrowsExactlyAsync<TException>(action);
         }
 
         private static string FormatValue<T>(T expected)

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -225,10 +225,10 @@
 	</PropertyGroup>
   	<PropertyGroup>
 	    <LibraryFramework>netstandard2.0</LibraryFramework>
-	    <TestFramework>net7.0</TestFramework>
-	    <MSTestVersion>3.0.2</MSTestVersion>
-	    <TestSdkVersion>17.5.0</TestSdkVersion>
-	    <AkkaVersion>1.5.27</AkkaVersion>
+	    <TestFramework>net8.0</TestFramework>
+	    <MSTestVersion>3.10.2</MSTestVersion>
+	    <TestSdkVersion>17.14.1</TestSdkVersion>
+	    <AkkaVersion>1.6.0</AkkaVersion>
   	</PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>


### PR DESCRIPTION
Contains codes needed to conform to the FluentAssertions changes in Akka 1.6 branch.

Will not work until Akka 1.6.0 (or beta) is released.