### PR TITLE
Bump AkkaVersion to 1.5.60

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -228,7 +228,7 @@
 	    <TestFramework>net7.0</TestFramework>
 	    <MSTestVersion>3.0.2</MSTestVersion>
 	    <TestSdkVersion>17.5.0</TestSdkVersion>
-	    <AkkaVersion>1.5.47</AkkaVersion>
+	    <AkkaVersion>1.5.60</AkkaVersion>
   	</PropertyGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Updates Akka.NET dependency from 1.5.47 to 1.5.60

## Changes
- Updated `AkkaVersion` property in `src/Directory.Build.props` to 1.5.60

This update brings compatibility with the latest Akka.NET release and includes all improvements and bug fixes from versions 1.5.48 through 1.5.60.