### PR TITLE
Enable dual targeting

### DIFF
--- a/.github/workflows/pr_validation.yml
+++ b/.github/workflows/pr_validation.yml
@@ -29,6 +29,11 @@ jobs:
         with:
           global-json-file: "./global.json"
 
+      - name: "Install .NET 6 SDK"
+        uses: actions/setup-dotnet@v4.3.1
+        with:
+          dotnet-version: '6.x'
+
       - name: "Restore .NET tools"
         run: dotnet tool restore
 
@@ -64,6 +69,11 @@ jobs:
         uses: actions/setup-dotnet@v4.3.1
         with:
           global-json-file: "./global.json"
+
+      - name: "Install .NET 6 SDK"
+        uses: actions/setup-dotnet@v4.3.1
+        with:
+          dotnet-version: '6.x'
 
       - name: "Restore .NET tools"
         run: dotnet tool restore

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,8 +20,8 @@
   </ItemGroup>
 
   <PropertyGroup>
-    <LibraryFramework>netstandard2.0</LibraryFramework>
-    <TestFramework>net8.0</TestFramework>
+    <LibraryFramework>netstandard2.0;net8.0</LibraryFramework>
+    <TestFramework>net6.0;net8.0</TestFramework>
   </PropertyGroup>
 
   <!-- SourceLink support for all Akka.NET projects -->

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,19 +3,31 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- Nuget package versions -->
     <AkkaVersion>1.5.60</AkkaVersion>
-    <MSTestVersion>3.0.2</MSTestVersion>
+    <MSTestVersion>3.10.0</MSTestVersion>
+    <MSTest4Version>4.1.0</MSTest4Version>
     <TestSdkVersion>17.5.0</TestSdkVersion>
   </PropertyGroup>
   <!-- App dependencies -->
   <ItemGroup>
     <PackageVersion Include="Akka.TestKit" Version="$(AkkaVersion)" />
+  </ItemGroup>
+  <!-- MSTest: 3.x for < net8.0, 4.x for net8.0+ -->
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <PackageVersion Include="MSTest.TestFramework" Version="$(MSTestVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PackageVersion Include="MSTest.TestFramework" Version="$(MSTest4Version)" />
   </ItemGroup>
   <!-- Test dependencies -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="$(TestSdkVersion)" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="$(MSTestVersion)" />
     <PackageVersion Include="coverlet.collector" Version="3.2.0" />
+  </ItemGroup>
+  <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PackageVersion Include="MSTest.TestAdapter" Version="$(MSTestVersion)" />
+  </ItemGroup>
+  <ItemGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
+    <PackageVersion Include="MSTest.TestAdapter" Version="$(MSTest4Version)" />
   </ItemGroup>
   <!-- SourceLink support for all Akka.NET projects -->
   <ItemGroup>

--- a/src/Akka.TestKit.MsTest.Tests/Akka.TestKit.MsTest.Tests.csproj
+++ b/src/Akka.TestKit.MsTest.Tests/Akka.TestKit.MsTest.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(TestFramework)</TargetFramework>
+    <TargetFrameworks>$(TestFramework)</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>

--- a/src/Akka.TestKit.MsTest.Tests/AssertionsTests.cs
+++ b/src/Akka.TestKit.MsTest.Tests/AssertionsTests.cs
@@ -20,17 +20,15 @@ namespace Akka.TestKit.MsTest.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(AssertFailedException))]
         public void Fail_should_throw()
         {
-            _assertions!.Fail();
+            Assert.ThrowsExactly<AssertFailedException>(() => _assertions!.Fail());
         }
 
         [TestMethod]
-        [ExpectedException(typeof(AssertFailedException))]
         public void AssertTrue_should_throw_on_false()
         {
-            _assertions!.AssertTrue(false);
+            Assert.ThrowsExactly<AssertFailedException>(() => _assertions!.AssertTrue(false));
         }
 
         [TestMethod]
@@ -40,10 +38,9 @@ namespace Akka.TestKit.MsTest.Tests
         }
 
         [TestMethod]
-        [ExpectedException(typeof(AssertFailedException))]
         public void AssertFalse_should_throw_on_true()
         {
-            _assertions!.AssertFalse(true);
+            Assert.ThrowsExactly<AssertFailedException>(() => _assertions!.AssertFalse(true));
         }
 
         [TestMethod]
@@ -54,10 +51,9 @@ namespace Akka.TestKit.MsTest.Tests
 
 
         [TestMethod]
-        [ExpectedException(typeof(AssertFailedException))]
         public void AssertEqual_should_throw_on_not_equal()
         {
-            _assertions!.AssertEqual(42, 4711);
+            Assert.ThrowsExactly<AssertFailedException>(() => _assertions!.AssertEqual(42, 4711));
         }
 
         [TestMethod]
@@ -68,10 +64,9 @@ namespace Akka.TestKit.MsTest.Tests
 
 
         [TestMethod]
-        [ExpectedException(typeof(AssertFailedException))]
         public void AssertEqualWithComparer_should_throw_on_not_equal()
         {
-            _assertions!.AssertEqual(42, 42,(x,y)=>false);
+            Assert.ThrowsExactly<AssertFailedException>(() => _assertions!.AssertEqual(42, 42, (x, y) => false));
         }
 
         [TestMethod]

--- a/src/Akka.TestKit.MsTest/Akka.TestKit.MsTest.csproj
+++ b/src/Akka.TestKit.MsTest/Akka.TestKit.MsTest.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>$(LibraryFramework)</TargetFramework>
+    <TargetFrameworks>$(LibraryFramework)</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <Description>MSTest support for the Akka.NET Testkit.</Description>
     <PackageTags>akka;testkit;mstest;akka.net;akkadotnet</PackageTags>

--- a/src/Akka.TestKit.MsTest/MsTestAssertions.cs
+++ b/src/Akka.TestKit.MsTest/MsTestAssertions.cs
@@ -16,29 +16,28 @@ namespace Akka.TestKit.MsTest
     {
         public void Fail(string format = "", params object[] args)
         {
-            Assert.Fail(format, args);
+            Assert.Fail(string.Format(format, args));
         }
 
         public void AssertTrue(bool condition, string format = "", params object[] args)
         {
-            Assert.IsTrue(condition,format, args);
+            Assert.IsTrue(condition, string.Format(format, args));
         }
 
         public void AssertFalse(bool condition, string format = "", params object[] args)
         {
-
-            Assert.IsFalse(condition,format, args);
+            Assert.IsFalse(condition, string.Format(format, args));
         }
 
         public void AssertEqual<T>(T expected, T actual, string format = "", params object[] args)
         {
-            Assert.AreEqual(expected,actual,format,args);
+            Assert.AreEqual(expected, actual, string.Format(format, args));
         }
 
         public void AssertEqual<T>(T expected, T actual, Func<T, T, bool> comparer, string format = "", params object[] args)
-        {            
+        {
             if(!comparer(expected, actual))
-                throw new AssertFailedException(string.Format("Assert.AreEqual failed. Expected [{0}]. Actual [{1}]. {2}", FormatValue(expected), FormatValue(actual), string.Format(format,args)));
+                throw new AssertFailedException($"Assert.AreEqual failed. Expected [{FormatValue(expected)}]. Actual [{FormatValue(actual)}]. {string.Format(format, args)}");
         }
 
         private static string FormatValue<T>(T expected)


### PR DESCRIPTION
## Changes

* Enable dual targeting for netstandard2.0 and net8.0
* netstandard2.0 target uses MSTest 3.x, tested using net6.0
* net8.0 target uses MSTest 4.x, tested using net8.0