### PR TITLE
Update RELEASE_NOTES.md for 1.5.60 release

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,11 @@
+#### 1.5.60 February 18th 2026 ####
+- Upgraded to [Akka.NET v1.5.60](https://github.com/akkadotnet/akka.net/releases/tag/1.5.60)
+- Added dual targeting for `netstandard2.0` and `net8.0`
+
+**MSTest 4.x support**
+
+MSTest 4.x support has been added for net8.0 build framework target and above
+
 #### 1.5.0 March 7th 2023 ####
 - Upgraded to [Akka.NET v1.5.0](https://github.com/akkadotnet/akka.net/releases/tag/1.5.0) and includes some breaking changes.
 


### PR DESCRIPTION
## 1.5.60 February 18th 2026
- Upgraded to [Akka.NET v1.5.60](https://github.com/akkadotnet/akka.net/releases/tag/1.5.60)
- Added dual targeting for `netstandard2.0` and `net8.0`

**MSTest 4.x support**

MSTest 4.x support has been added for net8.0 build framework target and above